### PR TITLE
fix the bug with multiple calls to Request.end 

### DIFF
--- a/lib/ApiRequest.js
+++ b/lib/ApiRequest.js
@@ -124,7 +124,8 @@ class ApiRequest extends Request {
    */
 
   end () {
-    return new Promise((resolve, reject) =>
+		if (!this._endPromise){
+			this._endPromise =  new Promise((resolve, reject) =>
       super.end((error, response) => {
         if (error) {
           return reject(error)
@@ -139,7 +140,8 @@ class ApiRequest extends Request {
 
         return resolve(body)
       })
-    )
+    )}
+		return this._endPromise;
   }
 
   /**

--- a/test/ApiRequest.test.js
+++ b/test/ApiRequest.test.js
@@ -37,6 +37,13 @@ describe('ApiRequest', () => {
     assert(request.end() instanceof Promise)
   })
 
+  it('will return same promise from second call of end()', () => {
+    const request = new ApiRequest('GET', '/')
+		const firstEndPromise = request.end()
+		const secondEndPromise = request.end()
+    assert(firstEndPromise === secondEndPromise)
+  })
+
   it('can be resolved', done => {
     const request = new ApiRequest('GET', '/')
     Promise.resolve(request).catch(() => done())


### PR DESCRIPTION
Method ApiRequest.then call ApiRequest.end. The code 
`const request = new ApiRequest('GET', '/')
const promise = request.end()
promise.then(/*do something*/)
promise.then(/*do something more*/)`
will produce an error because superagent doesn't support two calls to Request.end methods.