### PR TITLE
Match uses is for null & boolean values

### DIFF
--- a/lib/ApiRequest.js
+++ b/lib/ApiRequest.js
@@ -56,7 +56,13 @@ class ApiRequest extends Request {
 
   match (query) {
     const newQuery = {}
-    Object.keys(query).forEach(key => newQuery[key] = `eq.${query[key]}`)
+    Object.keys(query).forEach(key => {
+      const value = query[key]
+      const operator = (typeof value === 'boolean' || value === null)
+        ? 'is'
+        : 'eq'
+      newQuery[key] = `${operator}.${value}`
+    })
     return this.query(newQuery)
   }
 

--- a/test/ApiRequest.test.js
+++ b/test/ApiRequest.test.js
@@ -25,6 +25,11 @@ describe('ApiRequest', () => {
     assert.deepEqual(qs, { key1: 'eq.value1', key2: 'eq.value2' })
   })
 
+  it('will use `is` for null and boolean match values', () => {
+    const { qs } = new ApiRequest('GET', '/').match({ key1: null, key2: false })
+    assert.deepEqual(qs, { key1: 'is.null', key2: 'is.false' })
+  })
+
   it('won‘t assign to the passed match() filter', () => {
     const match = { key1: 'value1', key2: 'value2' }
     const { qs } = new ApiRequest('GET', '/').match(match)


### PR DESCRIPTION
closes #7. Note that this doesn't include the built version; not sure how you prefer to handle those with PRs.